### PR TITLE
Simplify string normalization - don't convert numeric strings to numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,53 +1,82 @@
 # CHANGELOG
 
+## 1.0.13
+
+### Fixes
+
+- Simplify string normalization: numeric strings now stay as strings instead of being converted to numbers. This fixes issues where `device.appBuildString == "5690201"` would fail because the string was incorrectly converted to an integer. Only "true" and "false" strings are converted to booleans; all other strings remain as strings. Removed the complex `extract_string_compared_variables` mechanism in favor of this simpler approach.
+
+## 1.0.12
+
+### Fixes
+
+- Fix string literal normalization in expressions where quoted strings like `"5690201"` were incorrectly converted to integers
+
+## 1.0.11
+
+### Fixes
+
+- Fix string-to-number normalization for variables compared against string literals (e.g., version comparisons like `"009.000" > "007.003.001"`)
+
 ## 1.0.10
 
-## Fixes
+### Fixes
+
 - Removes modulemap from outputs
 
 ## 1.0.9
 
 ## Fixes
+
 - Ensures XC projects also work with module SPM setup
+
 ## 1.0.8
 
 ## Fixes
+
 - Fix generic module name
 
 ## 1.0.7
 
 ## Fixes
+
 - Fix iOS build script
 
 ## 1.0.6
 
 ## Fixes
+
 - Ensure new module headers point to right places
 
 ## 1.0.5
 
 ## Fixes
+
 - Fixes namespaces for SPM module headers
 
 ## 1.0.4
 
 ## Enhancements
+
 - Disable Android Cleaner in UniFFI builds
 
 ## 1.0.3
 
 ## Enhancements
+
 - Ensure that previously set compilation flags do not affect Android compilation
 - Add flags to ensure common page size is being passed to Cross
 
 ## 1.0.2.
 
 ## Enhancements
+
 - Removes log print, reduces binary size
 
 ## 1.0.1
 
 ## Enhancements
+
 - Adds `hasFn` function that checks for the existance of a function or returns `false`
 - Enhance `hasFn` and `has` checks to do the following:
   - If a `device.` or `computed.` function is used, or a variable is accessed in an expression
@@ -60,16 +89,19 @@
 - Removes `string.toBool()`,`string.toInt()`, `string.toFloat()` functions as every possible valid atom conversion is done in the AST
 
 ## General
+
 - Adds more tests, improves test coverage, adds displaying coverage badge
 - Improves `README.MD` and adds an `interpretation-flow.md` to serve as a guide for how things are interpreted
 
 ## 1.0.0
 
 ## Enhancements
+
 - Adds truthiness and string normalization so value such as "true", "false", "1.1" etc are treated as true, false, 1.1. This occurs on both left and right side of an expression.
 - Adds conversion methods `bool.toString()`, `float.toString()`, `int.toString()`, `bool.toString()` and `string.toBool()`,`string.toInt()`, `string.toFloat()` to enable typecasting in CEL
 
 ## Truthiness
+
 - Fixes issues with undeclared references for properties and functions by wrapping them in a has(x)? x : Null tertiary expression
 
 ## 0.2.8
@@ -91,17 +123,21 @@
 ## 0.2.5
 
 ### Enhancements
+
 - Moves the HostContext to a Sync version with callback
 - Updates Android NDK to support 16kb page sizes
 - Updates Uniffi version
 
 ## 0.2.4
+
 - Fix aarch64 build for Android
 
 ## 0.2.3
+
 - Fix aarch64 build for Android
 
 ## 0.2.2
+
 - Version bump for deployment purposes
 
 ## 0.2.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cel-eval"
-version = "1.0.10"
+version = "1.0.13"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.htmlž

--- a/tests/coverage_tests.rs
+++ b/tests/coverage_tests.rs
@@ -411,13 +411,17 @@ fn test_complex_device_computed_resolution() {
 #[test]
 fn test_all_atom_types_normalization() {
     // Test normalize_ast_variables with all atom types
+    // Note: Only "true" and "false" strings are converted to booleans.
+    // Numeric strings stay as strings because quoted literals should preserve their type.
     use cel_parser::Atom;
 
-    // Test string atom normalization
+    // Test that numeric string atoms stay as strings (not converted to numbers)
+    // This is correct behavior: "42" in an expression should stay as String("42")
     let string_atom = Atom::String(Arc::new("42".to_string()));
-    let result = normalize_ast_variables(string_atom);
-    assert_eq!(result, Atom::Int(42));
+    let result = normalize_ast_variables(string_atom.clone());
+    assert_eq!(result, string_atom); // Should stay as String
 
+    // Test "true" and "false" strings are converted to booleans
     let bool_string = Atom::String(Arc::new("true".to_string()));
     let result = normalize_ast_variables(bool_string);
     assert_eq!(result, Atom::Bool(true));
@@ -426,21 +430,23 @@ fn test_all_atom_types_normalization() {
     let result = normalize_ast_variables(false_string);
     assert_eq!(result, Atom::Bool(false));
 
+    // Large numeric strings stay as strings
     let uint_string = Atom::String(Arc::new("18446744073709551615".to_string()));
-    let result = normalize_ast_variables(uint_string);
-    assert_eq!(result, Atom::UInt(18446744073709551615));
+    let result = normalize_ast_variables(uint_string.clone());
+    assert_eq!(result, uint_string); // Should stay as String
 
+    // Float-like strings stay as strings
     let float_string = Atom::String(Arc::new("3.14159".to_string()));
-    let result = normalize_ast_variables(float_string);
-    assert_eq!(result, Atom::Float(3.14159));
+    let result = normalize_ast_variables(float_string.clone());
+    assert_eq!(result, float_string); // Should stay as String
 
     let fractional_zero = Atom::String(Arc::new("42.0".to_string()));
-    let result = normalize_ast_variables(fractional_zero);
-    assert_eq!(result, Atom::Int(42)); // Should convert to int
+    let result = normalize_ast_variables(fractional_zero.clone());
+    assert_eq!(result, fractional_zero); // Should stay as String
 
     let non_numeric = Atom::String(Arc::new("not_a_number".to_string()));
-    let result = normalize_ast_variables(non_numeric);
-    assert_eq!(result, Atom::String(Arc::new("not_a_number".to_string())));
+    let result = normalize_ast_variables(non_numeric.clone());
+    assert_eq!(result, non_numeric); // Should stay as String
 
     // Test non-string atoms (should return unchanged)
     let int_atom = Atom::Int(42);


### PR DESCRIPTION
## Summary

- Simplifies string normalization by not converting numeric strings to numbers at all
- Only "true" and "false" strings are converted to booleans
- All other strings (including numeric strings like "5690201") stay as strings
- Removes the complex `extract_string_compared_variables` mechanism in favor of this simpler approach

## What was the issue?

`device.appBuildString == "5690201"` was returning `false` even when `device.appBuildString` was the string `"5690201"`. The previous fix tried to selectively skip normalization using `extract_string_compared_variables`, but this was complex and had edge cases.

## The fix

Instead of selective normalization, we now simply don't convert numeric strings to numbers. Quoted strings stay as strings - if users want a number, they write it without quotes.

## Test plan

- [x] Run `cargo test --lib` - all 107 tests pass
- [x] Verify `device.appBuildString == "5690201"` returns `true` when variable is string `"5690201"`
- [x] Verify version string comparisons still work (`device.appVersionPadded > "007.003.001"`)
- [x] Verify "true"/"false" strings are still converted to booleans

🤖 Generated with [Claude Code](https://claude.com/claude-code)