### PR TITLE
Fan out iOS build dispatch to superscript-ios-next

### DIFF
--- a/.github/workflows/trigger-supercel-ios.yml
+++ b/.github/workflows/trigger-supercel-ios.yml
@@ -9,9 +9,23 @@ jobs:
   trigger_ios_build:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Superscript-iOS Workflow
+      # Legacy iOS repo. Bundles the xcframework directly in git, which
+      # bloats clones. Kept building during the migration window so any
+      # consumers still pinned to it keep getting updates.
+      - name: Trigger legacy Superscript-iOS Workflow
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.PAT }}
           repository: superwall/Superscript-iOS
+          event-type: update-build
+
+      # New slim iOS repo. Distributes the xcframework as a GitHub
+      # Release asset and uses SPM's binaryTarget(url:checksum:) instead
+      # of committing the binary. Once consumers (notably Superwall-iOS)
+      # have migrated, the legacy step above can be removed.
+      - name: Trigger superscript-ios-next Workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: superwall/superscript-ios-next
           event-type: update-build


### PR DESCRIPTION
## Summary

- Adds a parallel `repository_dispatch` step to `trigger-supercel-ios.yml` that notifies the new [`superwall/superscript-ios-next`](https://github.com/superwall/superscript-ios-next) repo on every push to `master`.
- Leaves the existing dispatch to `superwall/Superscript-iOS` in place so legacy consumers keep getting builds during the migration window.

## Why

`superscript-ios` commits the ~250 MB `libcel.xcframework` into git on every release, which has grown its history past 1.2 GB and makes SPM clones painfully slow. `superscript-ios-next` distributes the framework as a GitHub Release asset and uses SPM's `binaryTarget(url:checksum:)`, keeping the repo at ~60 KB.

This fan-out keeps both repos healthy during the cutover. Once `Superwall-iOS` and any other internal consumers move to `superscript-ios-next`, the legacy dispatch step can be deleted.

## Test plan

- [ ] Merge this PR
- [ ] Push something to `master` (or wait for the next real release) and confirm both `superscript-ios-next` and `Superscript-iOS` workflows fire
- [ ] Confirm `superscript-ios-next` produces a release with `libcel.xcframework.zip` attached and rewrites `Package.swift` with the new URL/checksum

🤖 Generated with [Claude Code](https://claude.com/claude-code)