### PR TITLE
Fix abort when a property call argument fails to resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### Fixes
 
 - Fixes a crash where an evaluation error inside a computed/device property call (e.g. an unquoted argument like `daysSince(app_install)`) panicked and aborted the host app. Evaluation errors now propagate and degrade to a non-matching result. (superwall/Superwall-iOS#500)
-- Switches the panic strategy to `unwind` and guards all FFI entry points (`evaluateWithContext`, `evaluateAstWithContext`, `evaluateAst`, `parseToAst`) with `catch_unwind`, so any future evaluator panic is returned as an `{"Err": ...}` result instead of killing the host process.
+- Switches the panic strategy to `unwind` and guards all FFI entry points (`evaluateWithContext`, `evaluateAstWithContext`, `evaluateAst`, `parseToAst`) with `catch_unwind`, so on the native iOS/Android builds any future evaluator panic is returned as an `{"Err": ...}` result instead of killing the host process. The WASM/npm build is unaffected by this guard (`wasm32-unknown-unknown` is abort-only); there the protection comes from the error-propagation fix above.
 - `parseToAst` now returns a serialized error instead of panicking when the expression does not parse.
+
+Version 1.0.14 is intentionally skipped: that tag was already used by the `superscript-ios-next` release pipeline.
 
 ## 1.0.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 1.0.15
+
+### Fixes
+
+- Fixes a crash where an evaluation error inside a computed/device property call (e.g. an unquoted argument like `daysSince(app_install)`) panicked and aborted the host app. Evaluation errors now propagate and degrade to a non-matching result. (superwall/Superwall-iOS#500)
+- Switches the panic strategy to `unwind` and guards all FFI entry points (`evaluateWithContext`, `evaluateAstWithContext`, `evaluateAst`, `parseToAst`) with `catch_unwind`, so any future evaluator panic is returned as an `{"Err": ...}` result instead of killing the host process.
+- `parseToAst` now returns a serialized error instead of panicking when the expression does not parse.
+
 ## 1.0.13
 
 ### Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,9 @@ debug=false
 incremental = false
 overflow-checks = false
 codegen-units = 1
-# Must stay "unwind": the FFI entry points rely on catch_unwind so a panic
-# (e.g. from a malformed remote expression) can't abort the host app.
+# Must stay "unwind": the uniffi FFI entry points rely on catch_unwind so a
+# panic (e.g. from a malformed remote expression) can't abort the host app.
+# No effect on wasm32-unknown-unknown, whose target spec is abort-only.
 panic = "unwind"
 strip = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cel-eval"
-version = "1.0.13"
+version = "1.0.15"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.htmlž
@@ -36,7 +36,9 @@ debug=false
 incremental = false
 overflow-checks = false
 codegen-units = 1
-panic = "abort"
+# Must stay "unwind": the FFI entry points rely on catch_unwind so a panic
+# (e.g. from a malformed remote expression) can't abort the host app.
+panic = "unwind"
 strip = true
 
 [workspace]

--- a/build_ios.sh
+++ b/build_ios.sh
@@ -95,19 +95,19 @@ done
 
 # For visionOS device
 SDKROOT="$(xcrun --sdk xros --show-sdk-path)" \
-cargo +nightly build -Zbuild-std=std,core,alloc,panic_abort --target=aarch64-apple-visionos --lib --release
+cargo +nightly build -Zbuild-std=std,core,alloc,panic_unwind --target=aarch64-apple-visionos --lib --release
 # For visionOS simulator
 SDKROOT="$(xcrun --sdk xrsimulator --show-sdk-path)" \
-cargo +nightly build -Zbuild-std=std,core,alloc,panic_abort --target=aarch64-apple-visionos-sim --lib --release
+cargo +nightly build -Zbuild-std=std,core,alloc,panic_unwind --target=aarch64-apple-visionos-sim --lib --release
 
 # For watchOS device
 SDKROOT="$(xcrun --sdk watchos --show-sdk-path)" \
-cargo +nightly build -Zbuild-std=std,core,alloc,panic_abort --target=arm64_32-apple-watchos --lib --release
+cargo +nightly build -Zbuild-std=std,core,alloc,panic_unwind --target=arm64_32-apple-watchos --lib --release
 # For watchOS simulator
 SDKROOT="$(xcrun --sdk watchsimulator --show-sdk-path)" \
-cargo +nightly build -Zbuild-std=std,core,alloc,panic_abort --target=aarch64-apple-watchos-sim --lib --release
+cargo +nightly build -Zbuild-std=std,core,alloc,panic_unwind --target=aarch64-apple-watchos-sim --lib --release
 SDKROOT="$(xcrun --sdk watchsimulator --show-sdk-path)" \
-cargo +nightly build -Zbuild-std=std,core,alloc,panic_abort --target=x86_64-apple-watchos-sim --lib --release
+cargo +nightly build -Zbuild-std=std,core,alloc,panic_unwind --target=x86_64-apple-watchos-sim --lib --release
 
 
 # Rename *.modulemap to module.modulemap

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,8 @@ pub trait ResultCallback: Send + Sync {
  * `Err` result. Expressions arrive from remote config, so a malformed one must
  * never abort the host app. Catching requires `panic = "unwind"`; keep
  * Cargo.toml and the `-Zbuild-std` flags in build_ios.sh in sync with that.
+ * On wasm32-unknown-unknown panics still trap (the target is abort-only), so
+ * the wasm build relies on errors being propagated rather than caught.
  */
 fn recovering_from_panics(body: impl FnOnce() -> String) -> String {
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(body)) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,12 +58,39 @@ pub trait ResultCallback: Send + Sync {
 }
 
 /**
+ * Runs the body of an FFI entry point, converting any panic into a serialized
+ * `Err` result. Expressions arrive from remote config, so a malformed one must
+ * never abort the host app. Catching requires `panic = "unwind"`; keep
+ * Cargo.toml and the `-Zbuild-std` flags in build_ios.sh in sync with that.
+ */
+fn recovering_from_panics(body: impl FnOnce() -> String) -> String {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(body)) {
+        Ok(result) => result,
+        Err(panic) => {
+            let message = panic
+                .downcast_ref::<&str>()
+                .map(|s| (*s).to_string())
+                .or_else(|| panic.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "unknown panic".to_string());
+            let error: Result<PassableValue, String> =
+                Err(format!("Expression evaluation panicked: {}", message));
+            serde_json::to_string(&error)
+                .unwrap_or_else(|_| "{\"Err\":\"Expression evaluation panicked\"}".to_string())
+        }
+    }
+}
+
+/**
  * Evaluate a CEL expression with the given AST
  * @param ast The AST Execution Context, serialized as JSON. This defines the AST, the variables, and the platform properties.
  * @param host The host context to use for resolving properties
  * @return The result of the evaluation, either "true" or "false"
  */
 pub fn evaluate_ast_with_context(definition: String, host: Arc<dyn HostContext>) -> String {
+    recovering_from_panics(move || evaluate_ast_with_context_impl(definition, host))
+}
+
+fn evaluate_ast_with_context_impl(definition: String, host: Arc<dyn HostContext>) -> String {
     let data: Result<ASTExecutionContext, _> = serde_json::from_str(definition.as_str());
     let data = match data {
         Ok(data) => data,
@@ -101,6 +128,10 @@ pub fn evaluate_ast_with_context(definition: String, host: Arc<dyn HostContext>)
  * @return The result of the evaluation, either "true" or "false"
  */
 pub fn evaluate_ast(ast: String) -> String {
+    recovering_from_panics(move || evaluate_ast_impl(ast))
+}
+
+fn evaluate_ast_impl(ast: String) -> String {
     let data: Result<JSONExpression, _> = serde_json::from_str(ast.as_str());
     let data: JSONExpression = match data {
         Ok(data) => data,
@@ -126,6 +157,10 @@ pub fn evaluate_ast(ast: String) -> String {
  */
 
 pub fn evaluate_with_context(definition: String, host: Arc<dyn HostContext>) -> String {
+    recovering_from_panics(move || evaluate_with_context_impl(definition, host))
+}
+
+fn evaluate_with_context_impl(definition: String, host: Arc<dyn HostContext>) -> String {
     let data: Result<ExecutionContext, _> = serde_json::from_str(definition.as_str());
     let data: ExecutionContext = match data {
         Ok(data) => data,
@@ -168,12 +203,22 @@ pub fn evaluate_with_context(definition: String, host: Arc<dyn HostContext>) -> 
 /**
  * Transforms a given CEL expression into a CEL AST, serialized as JSON.
  * @param expression The CEL expression to parse
- * @return The AST of the expression, serialized as JSON
+ * @return The AST of the expression, serialized as JSON on success, or a
+ * serialized `{"Err": ...}` if the expression does not parse.
  */
 pub fn parse_to_ast(expression: String) -> String {
-    let ast: Result<JSONExpression, _> = parse(expression.as_str()).map(|expr| expr.into());
-    let ast = ast.map_err(|err| err.to_string());
-    serde_json::to_string(&ast.unwrap()).unwrap()
+    recovering_from_panics(move || match parse(expression.as_str()) {
+        Ok(expr) => {
+            let ast: JSONExpression = expr.into();
+            serde_json::to_string(&ast)
+                .unwrap_or_else(|_| "{\"Err\":\"Failed to serialize AST\"}".to_string())
+        }
+        Err(err) => {
+            let error: Result<JSONExpression, String> = Err(err.to_string());
+            serde_json::to_string(&error)
+                .unwrap_or_else(|_| "{\"Err\":\"Failed to parse expression\"}".to_string())
+        }
+    })
 }
 
 /**
@@ -478,6 +523,18 @@ fn execute_with(
                 let host = host_clone.lock(); // Lock the host for safe access
                 match host {
                     Ok(host) => {
+                        // Resolving an argument can fail, e.g. an undeclared reference
+                        // like `daysSince(app_install)`. That must surface as an
+                        // `ExecutionError` (degraded to `Null` by `execute_with`),
+                        // never a panic — a panic here aborts the host app.
+                        let resolved_args = args
+                            .iter()
+                            .map(|expression| {
+                                ftx.ptx
+                                    .resolve(expression)
+                                    .map(|value| DisplayableValue(value).to_passable())
+                            })
+                            .collect::<Result<Vec<_>, ExecutionError>>()?;
                         let prop_result = prop_for(
                             if device.contains_key(&it.0) {
                                 PropType::Device
@@ -485,14 +542,7 @@ fn execute_with(
                                 PropType::Computed
                             },
                             name.clone(),
-                            Some(
-                                args.iter()
-                                    .map(|expression| {
-                                        DisplayableValue(ftx.ptx.resolve(expression).unwrap())
-                                            .to_passable()
-                                    })
-                                    .collect(),
-                            ),
+                            Some(resolved_args),
                             &*host,
                         );
 
@@ -1541,6 +1591,113 @@ mod tests {
             ctx,
         );
         assert_eq!(res, "{\"Ok\":{\"type\":\"Null\"}}");
+    }
+
+    /// Builds the execution context from superwall/Superwall-iOS#500: the
+    /// SDK passes the computed-property functions in both `computed` and
+    /// `device`, and the expression comes verbatim from dashboard config.
+    fn dashboard_definition(expression: &str) -> String {
+        format!(
+            r#"{{
+            "variables": {{
+                "map": {{
+                    "device": {{
+                        "type": "map",
+                        "value": {{
+                            "activeEntitlements": {{"type": "list", "value": []}},
+                            "daysSince_app_install": {{"type": "int", "value": 5}}
+                        }}
+                    }}
+                }}
+            }},
+            "computed": {{
+                "minutesSince": [{{"type": "string", "value": "event_name"}}],
+                "hoursSince": [{{"type": "string", "value": "event_name"}}],
+                "daysSince": [{{"type": "string", "value": "event_name"}}]
+            }},
+            "device": {{
+                "minutesSince": [{{"type": "string", "value": "event_name"}}],
+                "hoursSince": [{{"type": "string", "value": "event_name"}}],
+                "daysSince": [{{"type": "string", "value": "event_name"}}]
+            }},
+            "expression": "{}"
+        }}"#,
+            expression
+        )
+    }
+
+    // An unquoted function argument is an undeclared reference. This used to
+    // panic in the argument-resolution closure and abort the host app
+    // (superwall/Superwall-iOS#500); it must degrade to a non-matching result.
+    #[test]
+    fn test_undeclared_reference_in_function_args_returns_gracefully() {
+        let ctx = Arc::new(TestContext {
+            map: HashMap::new(),
+        });
+        let res = evaluate_with_context(dashboard_definition("daysSince(app_install) >= 1"), ctx);
+        assert_eq!(res, "{\"Ok\":{\"type\":\"Null\"}}");
+    }
+
+    // Same as above via the `device.` prefix — the syntax the dashboard
+    // displays for a stored `device.daysSince_app_install` property.
+    #[test]
+    fn test_undeclared_reference_in_device_function_args_returns_gracefully() {
+        let ctx = Arc::new(TestContext {
+            map: HashMap::new(),
+        });
+        let res = evaluate_with_context(
+            dashboard_definition("device.daysSince(app_install) >= 1"),
+            ctx,
+        );
+        assert_eq!(res, "{\"Ok\":{\"type\":\"Null\"}}");
+    }
+
+    // The full filter generated by the dashboard in the incident.
+    #[test]
+    fn test_full_dashboard_filter_with_undeclared_reference_does_not_panic() {
+        let ctx = Arc::new(TestContext {
+            map: HashMap::new(),
+        });
+        let res = evaluate_with_context(
+            dashboard_definition(
+                "(size(device.activeEntitlements) == 0) && (daysSince(app_install) >= 1)",
+            ),
+            ctx,
+        );
+        assert_eq!(res, "{\"Ok\":{\"type\":\"Null\"}}");
+    }
+
+    // Control: the correctly-quoted argument still resolves through the host.
+    #[test]
+    fn test_quoted_function_arg_still_resolves_via_host() {
+        let days_since = serde_json::to_string(&PassableValue::Int(5)).unwrap();
+        let ctx = Arc::new(TestContext {
+            map: [("daysSince".to_string(), days_since)]
+                .iter()
+                .cloned()
+                .collect(),
+        });
+        let res = evaluate_with_context(
+            dashboard_definition("daysSince(\\\"app_install\\\") >= 1"),
+            ctx,
+        );
+        assert_eq!(res, "{\"Ok\":{\"type\":\"bool\",\"value\":true}}");
+    }
+
+    #[test]
+    fn test_panic_guard_converts_panic_to_err_json() {
+        let res = recovering_from_panics(|| panic!("boom"));
+        assert_eq!(res, "{\"Err\":\"Expression evaluation panicked: boom\"}");
+    }
+
+    #[test]
+    fn test_parse_to_ast_invalid_expression_returns_err() {
+        let res = parse_to_ast("daysSince(".to_string());
+        assert!(
+            res.starts_with("{\"Err\":"),
+            "expected an Err result, got: {}",
+            res
+        );
     }
 
     #[test]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -15,12 +15,8 @@ wasm-bindgen-futures = "0.4.43"
 futures = "0.3.30"
 console_error_panic_hook = "0.1.7"
 
-[profile.release]
-lto = true
-opt-level = "z"  # Optimize for size.
-codegen-units = 1
-panic = "abort"
-strip=true
+# No [profile.release] here: cargo ignores profiles in non-root workspace
+# members; the workspace root's profile governs this crate too.
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false


### PR DESCRIPTION
## Summary

Root-cause fix for superwall/Superwall-iOS#500: a malformed audience filter authored in the dashboard (e.g. `daysSince(app_install)` — unquoted argument, i.e. an undeclared reference) hit an `.unwrap()` in the computed/device property closure (`src/lib.rs:491`). With `panic = "abort"` in the release profile, that panic called `std::process::abort()` and killed the host app during launch preloading — an unrecoverable crash loop, uncatchable from Swift/Kotlin, re-triggered on every relaunch because the same config is refetched.

## Changes

1. **Propagate argument-resolution errors instead of unwrapping.** The property-call closure now collects resolved args into a `Result` and returns the `ExecutionError`. `execute_with` already degrades `Undeclared reference` errors to `Null`, so the filter simply doesn't match — the Swift/Kotlin layers already handle that correctly.
2. **Make panics catchable and catch them at the FFI boundary.** Release profile switched to `panic = "unwind"` (and the `-Zbuild-std` lists in `build_ios.sh` from `panic_abort` to `panic_unwind`). All four uniffi entry points (`evaluateWithContext`, `evaluateAstWithContext`, `evaluateAst`, `parseToAst`) now wrap their bodies in `catch_unwind`, returning `{"Err": "Expression evaluation panicked: …"}` instead of aborting the host process. This is required inside the Rust bodies: the udl declares these as plain string-returning, so a panic reaching uniffi's scaffolding would still fatal-error on the Swift side. Likely also covers the panic class in #48.
3. **`parseToAst` returns a serialized error** for unparseable input instead of panicking. Success shape unchanged.
4. **Version → 1.0.15** (1.0.14 is skipped: superscript-ios-next already has a 1.0.14 tag, and its release workflow resolves the version from this `Cargo.toml` and skips existing tags — 1.0.14 would silently not publish).

## Tests

Six new tests in `cargo test --lib` (114 pass), including the exact incident filter mirrored from the SDK's execution context:

- `daysSince(app_install) >= 1`, `device.daysSince(app_install) >= 1`, and `(size(device.activeEntitlements) == 0) && (daysSince(app_install) >= 1)` → `{"Ok":{"type":"Null"}}` (no abort)
- control: `daysSince("app_install") >= 1` still resolves via the host → `true`
- panic guard → `{"Err": …}`; `parseToAst("daysSince(")` → `{"Err": …}`

Note: the three targets under `tests/` (`integration_tests`, `coverage_tests`, `display_tests`) don't compile on clean `master` either (they use `use super::*;` and private types) — pre-existing, untouched here.

## Notes for review

- The nightly `-Zbuild-std` watchOS/visionOS builds aren't verifiable locally; the dispatch-triggered CI run of `build_ios.sh` after merge is the real check for those targets.
- Expect a small binary-size increase from unwind tables — the cost of making panics catchable.
- Merging to `master` auto-dispatches builds to Superscript-iOS (legacy), superscript-ios-next, and Android — merge is effectively release.
- Downstream after ios-next publishes 1.0.15: bump the `.exact` pin in Superwall-iOS `Package.swift`/podspec (and the Android equivalent). The dashboard-side hardening suggested in superwall/Superwall-iOS#500 (validate `expression_cel` on save, property-picker free-text commit) is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)